### PR TITLE
Feature/one room sync fix

### DIFF
--- a/lib/src/api/interceptors.dart
+++ b/lib/src/api/interceptors.dart
@@ -47,7 +47,6 @@ class LogResponseInterceptor implements ResponseInterceptor {
     HEADER $header
     $_separator
     BODY ${body.toString().length > _maxBodyLen ? "LEN ${body.toString().length}" : body}
-    $_separator
     ${error == null ? "" : "$_separator\nERROR $error"} 
     """,
     );

--- a/lib/src/api/interceptors.dart
+++ b/lib/src/api/interceptors.dart
@@ -39,6 +39,7 @@ class LogResponseInterceptor implements ResponseInterceptor {
     final method = response.base.request?.method;
     final body = response.body;
     final header = response.headers;
+    final error = response.error;
     Log.writer.log(
       """
     MATRIX RESPONSE $method $url
@@ -46,7 +47,9 @@ class LogResponseInterceptor implements ResponseInterceptor {
     HEADER $header
     $_separator
     BODY ${body.toString().length > _maxBodyLen ? "LEN ${body.toString().length}" : body}
-        """,
+    $_separator
+    ${error == null ? "" : "$_separator\nERROR $error"} 
+    """,
     );
     return response;
   }

--- a/lib/src/services/local/base_sync_storage.dart
+++ b/lib/src/services/local/base_sync_storage.dart
@@ -11,6 +11,20 @@ abstract class BaseSyncStorage {
     Context? context,
   });
 
+  Future<Iterable<Room>> getRoomsByIds(
+    Iterable<RoomId>? roomIds, {
+    required int timelineLimit,
+    Iterable<UserId>? memberIds,
+    Context? context,
+  });
+
+  Future<Room?> getRoom(
+    RoomId id, {
+    int timelineLimit = 15,
+    required Iterable<UserId> memberIds,
+    Context? context,
+  });
+
   bool isReady();
 
   Future<void> setUserDelta(MyUser user);
@@ -18,13 +32,6 @@ abstract class BaseSyncStorage {
   Future<void> setRoom(Room room);
 
   Future<List<String?>?> getRoomIds();
-
-  Future<Iterable<Room>> getRoomsByIds(
-    Iterable<RoomId>? roomIds, {
-    Context? context,
-    required int timelineLimit,
-    Iterable<UserId>? memberIds,
-  });
 
   Future<Iterable<Room>> getRooms({
     Context? context,
@@ -45,13 +52,6 @@ abstract class BaseSyncStorage {
     RoomId roomId, {
     int count = 20,
     DateTime? fromTime,
-  });
-
-  Future<Room?> getRoom(
-    RoomId id, {
-    int timelineLimit = 15,
-    required Context context,
-    required Iterable<UserId> memberIds,
   });
 
   Future<String?> getToken();

--- a/lib/src/services/local/sync_storage.dart
+++ b/lib/src/services/local/sync_storage.dart
@@ -60,7 +60,7 @@ class SyncStorage implements BaseSyncStorage {
   Future<Room?> getRoom(
     RoomId id, {
     int timelineLimit = 15,
-    required Context context,
+    Context? context,
     required Iterable<UserId> memberIds,
   }) =>
       store.getRoom(

--- a/lib/src/store/store.dart
+++ b/lib/src/store/store.dart
@@ -94,7 +94,7 @@ abstract class Store {
   Future<Room?> getRoom(
     RoomId id, {
     int timelineLimit = 15,
-    required Context context,
+    Context? context,
     required Iterable<UserId> memberIds,
   }) =>
       getRoomsByIDs(

--- a/lib/src/updater/isolated/instruction.dart
+++ b/lib/src/updater/isolated/instruction.dart
@@ -38,6 +38,18 @@ class StopSyncInstruction extends StorageSyncInstruction<void> {}
 
 class GetRoomIDsInstruction extends Instruction<List<String?>> {}
 
+class GetRoomInstruction extends Instruction<Room> {
+  final String roomId;
+  final Context? context;
+  final List<UserId> memberIds;
+
+  GetRoomInstruction({
+    required this.roomId,
+    required this.context,
+    required this.memberIds,
+  });
+}
+
 class SaveRoomToDBInstruction extends Instruction<void> {
   final Room room;
 

--- a/lib/src/updater/isolated/iso_storage_sync.dart
+++ b/lib/src/updater/isolated/iso_storage_sync.dart
@@ -11,6 +11,8 @@ import 'isolate_runner.dart';
 import 'utils.dart';
 
 abstract class IsolateStorageSyncRunner {
+  static StreamSubscription<Room>? roomSyncSubscription;
+
   static Future<void> run(IsolateTransferModel transferModel) async {
     final message = transferModel.message;
     Log.setLogger(transferModel.loggerVariant);
@@ -67,6 +69,13 @@ abstract class IsolateStorageSyncRunner {
             sendPort.send(syncResult);
           } else if (instruction is LogoutInstruction) {
             await updater?.logout();
+          } else if (instruction is OneRoomSyncInstruction) {
+            roomSyncSubscription = updater
+                ?.startRoomSync(instruction.roomId)
+                .listen(sendPort.send);
+          } else if (instruction is CloseRoomSync) {
+            await roomSyncSubscription?.cancel();
+            await updater?.closeRoomSync();
           }
         });
 

--- a/lib/src/updater/isolated/isolate_runner.dart
+++ b/lib/src/updater/isolated/isolate_runner.dart
@@ -75,6 +75,13 @@ abstract class IsolateRunner {
             await updater?.saveRoomToDB(instruction.room);
             sendPort.send(null);
           }
+          if (instruction is GetRoomInstruction) {
+            await updater?.fetchRoomFromDB(
+              instruction.roomId,
+              context: instruction.context,
+              memberIds: instruction.memberIds,
+            );
+          }
 
           if (instruction is RequestInstruction) {
             await _executeRequest(updater, sendPort, instruction);

--- a/lib/src/updater/isolated/isolated_one_room_sync.dart
+++ b/lib/src/updater/isolated/isolated_one_room_sync.dart
@@ -10,6 +10,7 @@ import '../../util/logger.dart';
 import 'isolate_runner.dart';
 import 'utils.dart';
 
+@Deprecated("Use IsolateStorageSyncRunner cause db can be sink only in one isolate")
 abstract class IsolateOneRoomSyncRunner {
   static StreamSubscription<Room>? roomSyncSubscription;
 
@@ -32,7 +33,7 @@ abstract class IsolateOneRoomSyncRunner {
               message.myUser,
               Homeserver(message.homeserverUrl),
               message.storeLocation,
-              initSyncStorage: false, //Create sync with store
+              initSyncStorage: true, //Not create updater updater sync
             );
             updaterAvailable.complete();
             subscription?.cancel();
@@ -79,5 +80,7 @@ abstract class IsolateOneRoomSyncRunner {
   }
 }
 
+
+@Deprecated("Use SyncerInitialized")
 @immutable
 class OneRoomSyncerInitialized {}

--- a/lib/src/updater/isolated/isolated_one_room_sync.dart
+++ b/lib/src/updater/isolated/isolated_one_room_sync.dart
@@ -33,7 +33,7 @@ abstract class IsolateOneRoomSyncRunner {
               message.myUser,
               Homeserver(message.homeserverUrl),
               message.storeLocation,
-              initSyncStorage: true, //Not create updater updater sync
+              initSyncStorage: false, //Not create updater updater sync
             );
             updaterAvailable.complete();
             subscription?.cancel();

--- a/lib/src/updater/isolated/isolated_updater.dart
+++ b/lib/src/updater/isolated/isolated_updater.dart
@@ -61,7 +61,6 @@ class IsolatedUpdater extends Updater {
     Updater.register(_user.id, this);
 
     _syncMessageStream.listen((message) async {
-
       //On user update
       if (message is MinimizedUpdate) {
         final minimizedUpdate = message;
@@ -416,6 +415,20 @@ class IsolatedUpdater extends Updater {
           userId: user.id,
         ),
         port: _syncSendPort,
+      );
+
+  @override
+  Future<Room?> fetchRoomFromDB(
+    String roomId, {
+    Context? context,
+    List<UserId>? memberIds,
+  }) async =>
+      execute(
+        GetRoomInstruction(
+          roomId: roomId,
+          context: context ?? user.context,
+          memberIds: memberIds ?? [user.id],
+        ),
       );
 
   @override

--- a/lib/src/updater/updater.dart
+++ b/lib/src/updater/updater.dart
@@ -535,9 +535,6 @@ class Updater {
       }
     }
 
-    print(
-        "_networkService_networkService_networkService ${_user.accessToken!} ${roomId.toString()} ${until.toString()} ${receipt ? until.toString() : null}");
-
     await _networkService.setRoomsReadMarkers(
       accessToken: _user.accessToken!,
       roomId: roomId.toString(),

--- a/lib/src/updater/updater.dart
+++ b/lib/src/updater/updater.dart
@@ -137,6 +137,18 @@ class Updater {
     return roomUpdates;
   }
 
+  Future<Room?> fetchRoomFromDB(
+    String roomId, {
+    Context? context,
+    List<UserId>? memberIds,
+  }) async {
+    return _syncStorage.getRoom(
+      RoomId(roomId),
+      context: context ?? user.context,
+      memberIds: memberIds ?? [user.id],
+    );
+  }
+
   Future<void> closeRoomSync() async => oneRoomSync?.cancel();
 
   Future<void> saveRoomToDB(Room room) => _syncStorage.setRoom(room);
@@ -522,6 +534,9 @@ class Updater {
         );
       }
     }
+
+    print(
+        "_networkService_networkService_networkService ${_user.accessToken!} ${roomId.toString()} ${until.toString()} ${receipt ? until.toString() : null}");
 
     await _networkService.setRoomsReadMarkers(
       accessToken: _user.accessToken!,


### PR DESCRIPTION
Move one room sink logic into main sync isolate, cause drift can watch db change only for one db object 